### PR TITLE
Build VSIX during release; publish consumes release asset

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,14 +41,58 @@ jobs:
 
     - name: Enforce unit test coverage
       run: npm run test:coverage
-    
-    - name: Package extension
-      run: npx vsce package --out cbor-viewer.vsix
 
-    - name: Upload VSIX to GitHub Release assets
-      uses: softprops/action-gh-release@v2
-      with:
-        files: cbor-viewer.vsix
+    - name: Download VSIX from GitHub Release assets
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        node -e "
+        const fs=require('fs');
+        const https=require('https');
+        const owner=process.env.GITHUB_REPOSITORY.split('/')[0];
+        const repo=process.env.GITHUB_REPOSITORY.split('/')[1];
+        const tag=(process.env.GITHUB_REF_NAME||'').trim();
+        const token=(process.env.GH_TOKEN||'').trim();
+
+        function requestJson(url){
+          return new Promise((resolve,reject)=>{
+            const req=https.request(url,{headers:{'User-Agent':'vscode-cbor-viewer-ci','Accept':'application/vnd.github+json','Authorization':`Bearer ${token}`}},(res)=>{
+              let data='';
+              res.on('data',c=>data+=c);
+              res.on('end',()=>{
+                if(res.statusCode<200||res.statusCode>=300) return reject(new Error(`HTTP ${res.statusCode}: ${data}`));
+                resolve(JSON.parse(data));
+              });
+            });
+            req.on('error',reject);
+            req.end();
+          });
+        }
+
+        function download(url,outPath){
+          return new Promise((resolve,reject)=>{
+            const req=https.request(url,{headers:{'User-Agent':'vscode-cbor-viewer-ci','Accept':'application/octet-stream','Authorization':`Bearer ${token}`}},(res)=>{
+              if(res.statusCode!==200) return reject(new Error(`Download HTTP ${res.statusCode}`));
+              const file=fs.createWriteStream(outPath);
+              res.pipe(file);
+              file.on('finish',()=>file.close(resolve));
+            });
+            req.on('error',reject);
+            req.end();
+          });
+        }
+
+        (async()=>{
+          const rel=await requestJson(`https://api.github.com/repos/${owner}/${repo}/releases/tags/${encodeURIComponent(tag)}`);
+          const asset=(rel.assets||[]).find(a=>String(a.name||'').endsWith('.vsix'));
+          if(!asset){
+            console.error('No .vsix asset found on release for tag: '+tag);
+            process.exit(1);
+          }
+          await download(asset.url,'cbor-viewer.vsix');
+          console.log('Downloaded VSIX: cbor-viewer.vsix');
+        })().catch(e=>{console.error(e);process.exit(1);});
+        "
     
     - name: Upload VSIX as artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,13 +72,14 @@ jobs:
             });
 
       - name: Create GitHub Release
+        id: create_release
         uses: actions/github-script@v7
         with:
           script: |
             const tag = '${{ steps.ver.outputs.tag }}';
             const version = '${{ steps.ver.outputs.version }}';
             const draft = ${{ inputs.draft }};
-            await github.rest.repos.createRelease({
+            const release = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: tag,
@@ -87,3 +88,23 @@ jobs:
               prerelease: /-/.test(version),
               generate_release_notes: true
             });
+
+            core.setOutput('upload_url', release.data.upload_url);
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Enforce unit test coverage
+        run: npm run test:coverage
+
+      - name: Package VSIX
+        run: npx vsce package --out cbor-viewer.vsix
+
+      - name: Upload VSIX to GitHub Release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.ver.outputs.tag }}
+          files: cbor-viewer.vsix


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for publishing and releasing the VS Code CBOR Viewer extension. The main focus is to improve the handling of the VSIX package artifact, ensuring it is consistently downloaded from release assets during publish, and streamlining the release process to correctly create and upload the VSIX to GitHub Releases.

**Workflow improvements:**

* In the `publish.yml` workflow, replaced the step that packaged the extension locally and uploaded it to the release with a script that downloads the existing VSIX package from the GitHub Release assets, ensuring the published artifact matches the released version.

**Release process enhancements:**

* In the `release.yml` workflow, updated the release creation step to capture the release upload URL as an output, which can be used in subsequent steps.
* Added steps to install dependencies, lint, run tests, and package the VSIX before uploading it to the GitHub Release assets, making the release process more robust and automated.