### PR TITLE
Users/jstatia/fix vsix

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,3 +12,4 @@ eslint.config.mjs
 **/*.ts
 !out/**/*.d.ts
 .github/**
+coverage/**


### PR DESCRIPTION
This pull request makes a minor update to the `.vscodeignore` file by excluding the `coverage` directory from the VS Code workspace. This helps prevent coverage reports from cluttering the workspace.