### PR TITLE
fix: exempt @vscode/vsce from minimatch override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1508,6 +1508,24 @@
         "win32"
       ]
     },
+    "node_modules/@vscode/vsce/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vscode/vsce/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/@vscode/vsce/node_modules/glob": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
@@ -1530,6 +1548,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/minimatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/acorn": {
@@ -2141,6 +2172,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -146,6 +146,9 @@
   },
   "overrides": {
     "minimatch": "^10.2.1",
+    "@vscode/vsce": {
+      "minimatch": "^3.0.3"
+    },
     "diff": "^8.0.3"
   }
 }


### PR DESCRIPTION
## Problem

The \minimatch\ npm override to \^10.2.1\ broke \@vscode/vsce\ packaging — minimatch 10.x changed its default export, causing \(0, minimatch_1.default) is not a function\ during \sce package\.

This broke the release workflow for v0.7.2 ([run #22367488580](https://github.com/JeromySt/vscode-cbor-viewer/actions/runs/22367488580)).

## Fix

Scope the override to exempt \@vscode/vsce\, which depends on \minimatch ^3.0.3\. All other packages (mocha, c8, eslint) still use minimatch 10.2.x.

## Verification
- \sce package\ succeeds locally
- All 174 unit tests pass
- ESLint passes